### PR TITLE
feat: removed login step after signup of new user

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -8,6 +8,8 @@ const Dashboard = () => {
     const token = localStorage.getItem("token");
     if (token) {
       localStorage.removeItem("token");
+      localStorage.removeItem("userID");
+      localStorage.removeItem("name");
       navigate("/");
     }
   };

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -17,9 +17,13 @@ const Login = () => {
           password: password,
         }
       );
-      const accessToken = response.data.accessToken;
-      localStorage.setItem("token", accessToken);
-      if (accessToken) {
+      const token = response.data.accessToken;
+      const userName = response.data.user.name;
+      const userID = response.data.user.userID;
+      localStorage.setItem("token", token);
+      localStorage.setItem("userID", userID);
+      localStorage.setItem("name", userName);
+      if (token) {
         navigate("/dashboard");
       }
     } catch (error) {

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -21,8 +21,14 @@ const Signup = () => {
           password: password,
         }
       );
+      const token = response.data.accessToken;
+      const userName = response.data.user.name;
+      const userID = response.data.user.userID;
+      localStorage.setItem("token", token);
+      localStorage.setItem("userID", userID);
+      localStorage.setItem("name", userName);
       console.log(response);
-      navigate("/login");
+      navigate("/dashboard");
     } catch (error) {
       console.log(error);
     }

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -1,5 +1,5 @@
 const bcrypt = require("bcryptjs");
-
+const jwt = require("jsonwebtoken");
 const { statusCodes } = require("../../utils/statusCodes");
 const { User } = require("../../models/User");
 const { setTime } = require("../../utils/time");
@@ -30,7 +30,19 @@ const signup = async (req, res) => {
       createdAt: setTime(),
     });
     await user.save();
-    return res.status(statusCodes.SUCCESS).json(user);
+
+    const token = await jwt.sign(
+      {
+        userID: user.userID,
+        name: user.name,
+        email: user.email,
+        password: user.password,
+      },
+      process.env.JWT_SECRET,
+      { expiresIn: "3h" }
+    );
+
+    return res.status(statusCodes.SUCCESS).json({ user, accessToken: token });
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
Fixes #11 

## Proposed Changes
- New users can directly be given access to their dashboard without need to login.
- JWT is signed to users at the time of signup with payload `userID`, `name`, `email`,`password`.
- This JWT is then validated before giving access to dashboard.
- This removes the repetitive task of logining in after signup and improves user experience